### PR TITLE
refactor: switch from failure to thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,10 @@ build = "build.rs"
 
 [dependencies]
 byteorder = "1.3"
-failure = "0.1"
+thiserror = "1.0.14"
+
+[dev-dependencies]
+skeptic = "0.13"
 
 [dev-dependencies.cargo-husky]
 version = "1"
@@ -21,9 +24,6 @@ default-features = false
 features = ["precommit-hook", "run-cargo-test", "run-cargo-clippy"]
 
 [build-dependencies]
-skeptic = "0.13"
-
-[dev-dependencies]
 skeptic = "0.13"
 
 [badges]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,6 @@
 
 use std::borrow::Cow;
-use failure::Fail;
+use thiserror::Error;
 
 
 
@@ -9,27 +9,14 @@ pub type ImageResultU = Result<(), ImageError>;
 
 
 
-#[derive(Fail, Debug)]
+#[derive(Debug, Error)]
 pub enum ImageError {
-    #[fail(display = "Corrupt image: {}", 0)]
+    #[error("Corrupt image: {0}")]
     CorruptImage(Cow<'static, str>),
-    #[fail(display = "Invalid signature")]
+    #[error("Invalid signature")]
     InvalidSignature,
-    #[fail(display = "IO Error: {}", 0)]
-    Io(std::io::Error),
-    #[fail(display = "Unsupported format")]
+    #[error("IO Error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Unsupported format")]
     Unsupported,
 }
-
-
-macro_rules! define_error {
-    ($source:ty, $kind:ident) => {
-        impl From<$source> for ImageError {
-            fn from(error: $source) -> ImageError {
-                ImageError::$kind(error)
-            }
-        }
-    }
-}
-
-define_error!(std::io::Error, Io);


### PR DESCRIPTION
Failure is about to be deprecated, for details see
- https://internals.rust-lang.org/t/failure-crate-maintenance/12087/5
- https://boats.gitlab.io/blog/post/failure-to-fehler/